### PR TITLE
Update alarm_control_panel.py

### DIFF
--- a/alarm_control_panel.py
+++ b/alarm_control_panel.py
@@ -163,6 +163,8 @@ class Concord4AlarmPanel(AlarmControlPanelEntity):
                 return STATE_ALARM_ARMED_AWAY
             case "stay":
                 return STATE_ALARM_ARMED_HOME
+            case "home":     ###adde case to match return from panel
+                return STATE_ALARM_ARMED_HOME
             case _:
                 return None
 


### PR DESCRIPTION
Fix error preventing concord4ws from starting when panel armed to stay - instant, from keypad. Panel returned home, code was looking for stay? Please review as I am not familiar enough with this to know if there are other impacts, but it solved this error for me. Feel free to modify or reject as appropriate.
Error:
``
2025-02-02 08:24:57.099 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Concord4 for concord4ws
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.13/site-packages/homeassistant/config_entries.py", line 637, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/homeassistant/.homeassistant/custom_components/concord4ws/__init__.py", line 28, in async_setup_entry
    await server.connect()
  File "/srv/homeassistant/lib/python3.13/site-packages/concord4ws/client.py", line 189, in connect
    await asyncio.sleep(0.1)
  File "/usr/lib/python3.13/asyncio/tasks.py", line 718, in sleep
    return await future
           ^^^^^^^^^^^^
asyncio.exceptions.CancelledError: Global task timeout
``